### PR TITLE
Fix issue when float values parses as integer

### DIFF
--- a/src/BodyParsers/FromText.php
+++ b/src/BodyParsers/FromText.php
@@ -77,7 +77,10 @@ class FromText implements BodyParserInterface
             }
 
             if (is_numeric($value)) {
-                return (int) $value;
+                if ((int) $value == $value) {
+                    return (int) $value;
+                }
+                return (float) $value;
             }
 
             return trim((string)$value);

--- a/tests/BodyParsers/FromTextTest.php
+++ b/tests/BodyParsers/FromTextTest.php
@@ -38,4 +38,17 @@ class FromTextTest extends TestCase
 
         $this->assertEquals($expected, $parser->parse($body));
     }
+
+    public function testParseWithNumeric()
+    {
+        $parser = new FromText();
+
+        $body = "Line 1\tTitle\tBody\t13.00\t14.50\t15.5000\t16";
+        
+        $expected = [
+            ['Line 1', 'Title', 'Body', 13, 14.50, 15.5, 16],
+        ];
+
+        $this->assertEquals($expected, $parser->parse($body));
+    }
 }


### PR DESCRIPTION
In the original solution, we always convert any numeric to the int. 

Because of that latitude and longitude values were always rounded.