### PR TITLE
Replace Guzzle with farzai/transport and optimize memory

### DIFF
--- a/bin/geonames
+++ b/bin/geonames
@@ -5,11 +5,14 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Symfony\Component\Console\Application;
-use Farzai\Geonames\Console\Commands\DownloadPostalCodesCommand;
+use Composer\InstalledVersions;
 use Farzai\Geonames\Console\Commands\DownloadGazetteerCommand;
+use Farzai\Geonames\Console\Commands\DownloadPostalCodesCommand;
+use Symfony\Component\Console\Application;
 
-$application = new Application('Geonames CLI', '1.0.0');
+$version = InstalledVersions::getPrettyVersion('farzai/geonames') ?? '1.0.0';
+
+$application = new Application('Geonames CLI', $version);
 $application->add(new DownloadPostalCodesCommand());
 $application->add(new DownloadGazetteerCommand());
-$application->run(); 
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,16 @@
     "require": {
         "php": "^8.1",
         "symfony/console": "^6.0 || ^7.0",
-        "guzzlehttp/guzzle": "^7.0"
+        "farzai/transport": "^2.1"
     },
     "require-dev": {
-        "pestphp/pest": "^2.34",
-        "spatie/ray": "^1.28",
         "laravel/pint": "^1.2",
+        "pestphp/pest": "^2.34",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-phpunit": "^1.0",
+        "spatie/ray": "^1.28",
+        "symfony/http-client": "^7.3"
     },
     "autoload": {
         "psr-4": {
@@ -48,7 +49,6 @@
         "analyse": "vendor/bin/phpstan analyse"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Required to download the data from Geonames.",
         "ext-zip": "Required to extract the downloaded data.",
         "mongodb/mongodb": "Required for MongoDB output format support."
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "spatie/ray": "^1.28",
-        "symfony/http-client": "^7.3"
+        "symfony/http-client": "^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/Commands/DownloadGazetteerCommand.php
+++ b/src/Console/Commands/DownloadGazetteerCommand.php
@@ -7,6 +7,7 @@ namespace Farzai\Geonames\Console\Commands;
 use Farzai\Geonames\Converter\GazetteerConverter;
 use Farzai\Geonames\Converter\MongoDBGazetteerConverter;
 use Farzai\Geonames\Downloader\GazetteerDownloader;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,6 +36,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *   geonames:gazetteer:download all -c P            # All populated places
  *   geonames:gazetteer:download US -f mongodb       # Import US data to MongoDB
  */
+#[AsCommand(
+    name: 'geonames:gazetteer:download',
+    description: 'Download and convert Geonames Gazetteer data'
+)]
 class DownloadGazetteerCommand extends Command
 {
     /**
@@ -44,20 +49,6 @@ class DownloadGazetteerCommand extends Command
         'admin1CodesASCII.txt',
         'admin2Codes.txt',
     ];
-
-    /**
-     * The default command name.
-     *
-     * @var string
-     */
-    protected static $defaultName = 'geonames:gazetteer:download';
-
-    /**
-     * The default command description.
-     *
-     * @var string
-     */
-    protected static $defaultDescription = 'Download and convert Geonames Gazetteer data';
 
     /**
      * The gazetteer downloader instance.

--- a/src/Console/Commands/DownloadPostalCodesCommand.php
+++ b/src/Console/Commands/DownloadPostalCodesCommand.php
@@ -7,6 +7,7 @@ namespace Farzai\Geonames\Console\Commands;
 use Farzai\Geonames\Converter\MongoDBPostalCodeConverter;
 use Farzai\Geonames\Converter\PostalCodeConverter;
 use Farzai\Geonames\Downloader\GeonamesDownloader;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,22 +25,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  *   geonames:download all             # Download all countries
  *   geonames:download US -f mongodb   # Import US data to MongoDB
  */
+#[AsCommand(
+    name: 'geonames:download',
+    description: 'Download and convert postal codes data from Geonames'
+)]
 class DownloadPostalCodesCommand extends Command
 {
-    /**
-     * The default command name.
-     *
-     * @var string
-     */
-    protected static $defaultName = 'geonames:download';
-
-    /**
-     * The default command description.
-     *
-     * @var string
-     */
-    protected static $defaultDescription = 'Download and convert postal codes data from Geonames';
-
     /**
      * The postal code downloader instance.
      */

--- a/src/Converter/AbstractConverter.php
+++ b/src/Converter/AbstractConverter.php
@@ -234,7 +234,7 @@ abstract class AbstractConverter implements ConverterInterface
      */
     protected function createProgressBar(int $totalLines): ?ProgressBar
     {
-        if ($this->output === null) {
+        if ($this->output === null || $totalLines <= 0) {
             return null;
         }
 

--- a/src/Converter/GazetteerConverter.php
+++ b/src/Converter/GazetteerConverter.php
@@ -5,17 +5,21 @@ declare(strict_types=1);
 namespace Farzai\Geonames\Converter;
 
 use Farzai\Geonames\Exceptions\GeonamesException;
+use Generator;
 
 /**
  * Converts GeoNames gazetteer data from ZIP files to JSON format.
  *
  * This converter extracts geographical feature data from GeoNames ZIP archives
  * and outputs it as a JSON file with administrative code name resolution.
+ * Uses streaming to handle large files with minimal memory usage.
  */
 class GazetteerConverter extends AbstractGazetteerConverter
 {
     /**
      * Process the gazetteer data file and write to JSON output.
+     *
+     * Uses streaming to process large files with O(1) memory complexity.
      *
      * @param  string  $txtFile  Path to the source TXT file containing gazetteer data
      * @param  string  $outputFile  Path to the output JSON file
@@ -24,32 +28,90 @@ class GazetteerConverter extends AbstractGazetteerConverter
      */
     protected function processFile(string $txtFile, string $outputFile): void
     {
-        $data = [];
-        $lines = file($txtFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $totalLines = $this->countLines($txtFile);
+        $progressBar = $this->createProgressBar($totalLines);
 
-        if ($lines === false) {
-            throw GeonamesException::fileOperationFailed('read', $txtFile);
+        $handle = fopen($outputFile, 'wb');
+        if ($handle === false) {
+            throw GeonamesException::fileOperationFailed('open for writing', $outputFile);
         }
 
-        foreach ($lines as $line) {
-            if (empty(trim($line))) {
-                continue;
+        try {
+            $this->writeToHandle($handle, '[', $outputFile);
+            $first = true;
+
+            foreach ($this->streamGazetteerRecords($txtFile) as $record) {
+                if (! $first) {
+                    $this->writeToHandle($handle, ',', $outputFile);
+                }
+
+                $json = json_encode($record, JSON_UNESCAPED_UNICODE);
+                if ($json === false) {
+                    throw GeonamesException::fileOperationFailed('encode JSON', $outputFile);
+                }
+
+                $this->writeToHandle($handle, $json, $outputFile);
+                $first = false;
+
+                $progressBar?->advance();
             }
 
-            $record = $this->parseGazetteerLine($line);
-            if ($record !== null) {
-                $data[] = $record;
-            }
+            $this->writeToHandle($handle, ']', $outputFile);
+        } finally {
+            fclose($handle);
+            $this->finishProgressBar($progressBar);
         }
+    }
 
-        $jsonContent = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-        if ($jsonContent === false) {
-            throw GeonamesException::fileOperationFailed('encode JSON', $outputFile);
-        }
-
-        $result = file_put_contents($outputFile, $jsonContent);
-        if ($result === false) {
+    /**
+     * Write content to a file handle with error checking.
+     *
+     * @param  resource  $handle  The file handle to write to
+     * @param  string  $content  The content to write
+     * @param  string  $outputFile  The output file path (for error messages)
+     *
+     * @throws GeonamesException When the write operation fails
+     */
+    private function writeToHandle($handle, string $content, string $outputFile): void
+    {
+        if (fwrite($handle, $content) === false) {
             throw GeonamesException::fileOperationFailed('write', $outputFile);
+        }
+    }
+
+    /**
+     * Stream gazetteer records from a TXT file.
+     *
+     * Uses a generator to yield records one at a time, enabling memory-efficient
+     * processing of large files.
+     *
+     * @param  string  $txtFile  Path to the TXT file containing gazetteer data
+     * @return Generator<int, array<string, mixed>> Yields gazetteer records
+     *
+     * @throws GeonamesException When the file cannot be opened
+     */
+    protected function streamGazetteerRecords(string $txtFile): Generator
+    {
+        $handle = fopen($txtFile, 'r');
+
+        if ($handle === false) {
+            throw GeonamesException::fileOperationFailed('open', $txtFile);
+        }
+
+        try {
+            while (($line = fgets($handle)) !== false) {
+                $trimmedLine = trim($line);
+                if (empty($trimmedLine)) {
+                    continue;
+                }
+
+                $record = $this->parseGazetteerLine($trimmedLine);
+                if ($record !== null) {
+                    yield $record;
+                }
+            }
+        } finally {
+            fclose($handle);
         }
     }
 }

--- a/tests/Feature/Console/DownloadGazetteerCommandTest.php
+++ b/tests/Feature/Console/DownloadGazetteerCommandTest.php
@@ -3,10 +3,7 @@
 use Farzai\Geonames\Console\Commands\DownloadGazetteerCommand;
 use Farzai\Geonames\Converter\GazetteerConverter;
 use Farzai\Geonames\Downloader\GazetteerDownloader;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -19,12 +16,10 @@ beforeEach(function () {
 
 describe('DownloadGazetteerCommand', function () {
     describe('configure', function () {
-        it('has default name static property', function () {
-            // Verify the class has the correct default name property
-            $reflection = new ReflectionClass(DownloadGazetteerCommand::class);
-            $property = $reflection->getProperty('defaultName');
+        it('has correct command name', function () {
+            $command = new DownloadGazetteerCommand;
 
-            expect($property->getValue())->toBe('geonames:gazetteer:download');
+            expect($command->getName())->toBe('geonames:gazetteer:download');
         });
 
         it('has country argument', function () {
@@ -74,15 +69,13 @@ describe('DownloadGazetteerCommand', function () {
             $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
             $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
 
-            // Create mock HTTP client for country data and admin codes
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
-                new Response(200, ['Content-Length' => strlen($admin1Content)], $admin1Content),
-                new Response(200, ['Content-Length' => strlen($admin2Content)], $admin2Content),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GazetteerDownloader($client);
+            $downloader = new GazetteerDownloader($transport);
             $converter = new GazetteerConverter;
 
             $command = new DownloadGazetteerCommand($downloader, $converter);
@@ -103,14 +96,13 @@ describe('DownloadGazetteerCommand', function () {
             $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
             $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
-                new Response(200, ['Content-Length' => strlen($admin1Content)], $admin1Content),
-                new Response(200, ['Content-Length' => strlen($admin2Content)], $admin2Content),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GazetteerDownloader($client);
+            $downloader = new GazetteerDownloader($transport);
             $converter = new GazetteerConverter;
 
             $command = new DownloadGazetteerCommand($downloader, $converter);
@@ -135,14 +127,13 @@ describe('DownloadGazetteerCommand', function () {
             $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
             $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
-                new Response(200, ['Content-Length' => strlen($admin1Content)], $admin1Content),
-                new Response(200, ['Content-Length' => strlen($admin2Content)], $admin2Content),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GazetteerDownloader($client);
+            $downloader = new GazetteerDownloader($transport);
             $converter = new GazetteerConverter;
 
             $command = new DownloadGazetteerCommand($downloader, $converter);
@@ -165,14 +156,13 @@ describe('DownloadGazetteerCommand', function () {
             $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
             $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
-                new Response(200, ['Content-Length' => strlen($admin1Content)], $admin1Content),
-                new Response(200, ['Content-Length' => strlen($admin2Content)], $admin2Content),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GazetteerDownloader($client);
+            $downloader = new GazetteerDownloader($transport);
             $converter = new GazetteerConverter;
 
             $command = new DownloadGazetteerCommand($downloader, $converter);

--- a/tests/Feature/Console/DownloadPostalCodesCommandTest.php
+++ b/tests/Feature/Console/DownloadPostalCodesCommandTest.php
@@ -3,10 +3,7 @@
 use Farzai\Geonames\Console\Commands\DownloadPostalCodesCommand;
 use Farzai\Geonames\Converter\PostalCodeConverter;
 use Farzai\Geonames\Downloader\GeonamesDownloader;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -19,12 +16,10 @@ beforeEach(function () {
 
 describe('DownloadPostalCodesCommand', function () {
     describe('configure', function () {
-        it('has default name static property', function () {
-            // Verify the class has the correct default name property
-            $reflection = new ReflectionClass(DownloadPostalCodesCommand::class);
-            $property = $reflection->getProperty('defaultName');
+        it('has correct command name', function () {
+            $command = new DownloadPostalCodesCommand;
 
-            expect($property->getValue())->toBe('geonames:download');
+            expect($command->getName())->toBe('geonames:download');
         });
 
         it('has country argument', function () {
@@ -64,14 +59,12 @@ describe('DownloadPostalCodesCommand', function () {
         it('downloads and converts to JSON successfully', function () {
             $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
 
-            // Create mock HTTP client
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            // Create real downloader with mocked client and real converter
-            $downloader = new GeonamesDownloader($client);
+            // Create real downloader with mocked transport and real converter
+            $downloader = new GeonamesDownloader($transport);
             $converter = new PostalCodeConverter;
 
             $command = new DownloadPostalCodesCommand($downloader, $converter);
@@ -90,12 +83,11 @@ describe('DownloadPostalCodesCommand', function () {
         it('downloads all countries when specified', function () {
             $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GeonamesDownloader($client);
+            $downloader = new GeonamesDownloader($transport);
             $converter = new PostalCodeConverter;
 
             $command = new DownloadPostalCodesCommand($downloader, $converter);
@@ -114,12 +106,11 @@ describe('DownloadPostalCodesCommand', function () {
         it('returns failure for unknown format', function () {
             $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GeonamesDownloader($client);
+            $downloader = new GeonamesDownloader($transport);
             $converter = new PostalCodeConverter;
 
             $command = new DownloadPostalCodesCommand($downloader, $converter);
@@ -140,12 +131,11 @@ describe('DownloadPostalCodesCommand', function () {
         it('creates output directory if it does not exist', function () {
             $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
 
-            $mock = new MockHandler([
-                new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
             ]);
-            $client = new Client(['handler' => HandlerStack::create($mock)]);
 
-            $downloader = new GeonamesDownloader($client);
+            $downloader = new GeonamesDownloader($transport);
             $converter = new PostalCodeConverter;
 
             $command = new DownloadPostalCodesCommand($downloader, $converter);

--- a/tests/Feature/DownloaderTest.php
+++ b/tests/Feature/DownloaderTest.php
@@ -2,10 +2,7 @@
 
 use Farzai\Geonames\Downloader\GazetteerDownloader;
 use Farzai\Geonames\Downloader\GeonamesDownloader;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
 
 beforeEach(function () {
     // Create test data if it doesn't exist
@@ -17,15 +14,11 @@ beforeEach(function () {
 test('postal codes downloader can download country data', function () {
     $zipContent = file_get_contents(__DIR__.'/../stubs/TH.zip');
 
-    // Create a mock response
-    $mock = new MockHandler([
-        new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
+    $transport = MockHttpClient::createTransport([
+        ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
     ]);
 
-    $handlerStack = HandlerStack::create($mock);
-    $client = new Client(['handler' => $handlerStack]);
-
-    $downloader = new GeonamesDownloader($client);
+    $downloader = new GeonamesDownloader($transport);
     $downloader->download('TH', $this->getTestDataPath());
 
     expect(file_exists($this->getTestDataPath('TH.zip')))->toBeTrue();
@@ -36,20 +29,61 @@ test('gazetteer downloader can download country data and admin codes', function 
     $admin1Content = file_get_contents(__DIR__.'/../stubs/admin1CodesASCII.txt');
     $admin2Content = file_get_contents(__DIR__.'/../stubs/admin2Codes.txt');
 
-    // Create mock responses for country data and admin codes
-    $mock = new MockHandler([
-        new Response(200, ['Content-Length' => strlen($zipContent)], $zipContent),
-        new Response(200, ['Content-Length' => strlen($admin1Content)], $admin1Content),
-        new Response(200, ['Content-Length' => strlen($admin2Content)], $admin2Content),
+    $transport = MockHttpClient::createTransport([
+        ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+        ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+        ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
     ]);
 
-    $handlerStack = HandlerStack::create($mock);
-    $client = new Client(['handler' => $handlerStack]);
-
-    $downloader = new GazetteerDownloader($client);
+    $downloader = new GazetteerDownloader($transport);
     $downloader->download('TH', $this->getTestDataPath());
 
     expect(file_exists($this->getTestDataPath('TH.zip')))->toBeTrue()
         ->and(file_exists($this->getTestDataPath('admin1CodesASCII.txt')))->toBeTrue()
         ->and(file_exists($this->getTestDataPath('admin2Codes.txt')))->toBeTrue();
+});
+
+test('gazetteer downloader downloadAll works', function () {
+    $zipContent = file_get_contents(__DIR__.'/../stubs/TH_gaz.zip');
+    $admin1Content = file_get_contents(__DIR__.'/../stubs/admin1CodesASCII.txt');
+    $admin2Content = file_get_contents(__DIR__.'/../stubs/admin2Codes.txt');
+
+    $transport = MockHttpClient::createTransport([
+        ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+        ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+        ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+    ]);
+
+    $downloader = new GazetteerDownloader($transport);
+    $downloader->downloadAll($this->getTestDataPath());
+
+    expect(file_exists($this->getTestDataPath('allCountries.zip')))->toBeTrue()
+        ->and(file_exists($this->getTestDataPath('admin1CodesASCII.txt')))->toBeTrue()
+        ->and(file_exists($this->getTestDataPath('admin2Codes.txt')))->toBeTrue();
+});
+
+test('postal downloader downloadAll works', function () {
+    $zipContent = file_get_contents(__DIR__.'/../stubs/TH.zip');
+
+    $transport = MockHttpClient::createTransport([
+        ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+    ]);
+
+    $downloader = new GeonamesDownloader($transport);
+    $downloader->downloadAll($this->getTestDataPath());
+
+    expect(file_exists($this->getTestDataPath('allCountries.zip')))->toBeTrue();
+});
+
+test('downloader handles empty Content-Length header', function () {
+    $zipContent = file_get_contents(__DIR__.'/../stubs/TH.zip');
+
+    $transport = MockHttpClient::createTransport([
+        ['content' => $zipContent, 'headers' => []],
+    ]);
+
+    $downloader = new GeonamesDownloader($transport);
+    $downloader->download('TH', $this->getTestDataPath());
+
+    expect(file_exists($this->getTestDataPath('TH.zip')))->toBeTrue();
 });

--- a/tests/Helpers/MockHttpClient.php
+++ b/tests/Helpers/MockHttpClient.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\Geonames\Tests\Helpers;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A mock PSR-18 HTTP client for testing.
+ */
+class MockHttpClient implements ClientInterface
+{
+    /**
+     * @var array<ResponseInterface>
+     */
+    private array $responses;
+
+    private int $currentIndex = 0;
+
+    /**
+     * @param  array<ResponseInterface>  $responses
+     */
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        if ($this->currentIndex >= count($this->responses)) {
+            throw new \RuntimeException('No more mock responses available');
+        }
+
+        return $this->responses[$this->currentIndex++];
+    }
+
+    /**
+     * Create mock responses from content.
+     *
+     * @param  array<array{content: string, headers?: array<string, array<string>>}>  $responseData
+     */
+    public static function withResponses(array $responseData): self
+    {
+        $responses = [];
+        foreach ($responseData as $data) {
+            $content = $data['content'];
+            $headers = $data['headers'] ?? ['Content-Length' => [strlen($content)]];
+            $responses[] = new MockResponse($content, $headers);
+        }
+
+        return new self($responses);
+    }
+
+    /**
+     * Create a Transport instance with mock responses for testing.
+     *
+     * @param  array<array{content: string, headers?: array<string, array<string>>}>  $responses
+     */
+    public static function createTransport(array $responses): \Farzai\Transport\Transport
+    {
+        $mockClient = self::withResponses($responses);
+
+        return \Farzai\Transport\TransportBuilder::make()
+            ->setClient($mockClient)
+            ->build();
+    }
+}
+
+/**
+ * A mock PSR-7 response.
+ */
+class MockResponse implements ResponseInterface
+{
+    private string $body;
+
+    /**
+     * @var array<string, array<string>>
+     */
+    private array $headers;
+
+    private MockStream $stream;
+
+    /**
+     * @param  array<string, array<string>>  $headers
+     */
+    public function __construct(string $body, array $headers = [])
+    {
+        $this->body = $body;
+        $this->headers = $headers;
+        $this->stream = new MockStream($body);
+    }
+
+    public function getStatusCode(): int
+    {
+        return 200;
+    }
+
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
+    {
+        return $this;
+    }
+
+    public function getReasonPhrase(): string
+    {
+        return 'OK';
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return '1.1';
+    }
+
+    public function withProtocolVersion(string $version): ResponseInterface
+    {
+        return $this;
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function hasHeader(string $name): bool
+    {
+        return isset($this->headers[$name]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getHeader(string $name): array
+    {
+        return $this->headers[$name] ?? [];
+    }
+
+    public function getHeaderLine(string $name): string
+    {
+        return implode(', ', $this->getHeader($name));
+    }
+
+    /**
+     * @param  string|array<string>  $value
+     */
+    public function withHeader(string $name, $value): ResponseInterface
+    {
+        return $this;
+    }
+
+    /**
+     * @param  string|array<string>  $value
+     */
+    public function withAddedHeader(string $name, $value): ResponseInterface
+    {
+        return $this;
+    }
+
+    public function withoutHeader(string $name): ResponseInterface
+    {
+        return $this;
+    }
+
+    public function getBody(): StreamInterface
+    {
+        return $this->stream;
+    }
+
+    public function withBody(StreamInterface $body): ResponseInterface
+    {
+        return $this;
+    }
+}
+
+/**
+ * A mock PSR-7 stream.
+ */
+class MockStream implements StreamInterface
+{
+    private string $content;
+
+    private int $position = 0;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+
+    public function __toString(): string
+    {
+        return $this->content;
+    }
+
+    public function close(): void {}
+
+    public function detach()
+    {
+        return null;
+    }
+
+    public function getSize(): ?int
+    {
+        return strlen($this->content);
+    }
+
+    public function tell(): int
+    {
+        return $this->position;
+    }
+
+    public function eof(): bool
+    {
+        return $this->position >= strlen($this->content);
+    }
+
+    public function isSeekable(): bool
+    {
+        return true;
+    }
+
+    public function seek(int $offset, int $whence = SEEK_SET): void
+    {
+        $this->position = $offset;
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function write(string $string): int
+    {
+        return 0;
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function read(int $length): string
+    {
+        $data = substr($this->content, $this->position, $length);
+        $this->position += strlen($data);
+
+        return $data;
+    }
+
+    public function getContents(): string
+    {
+        $remaining = substr($this->content, $this->position);
+        $this->position = strlen($this->content);
+
+        return $remaining;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getMetadata(?string $key = null)
+    {
+        return $key === null ? [] : null;
+    }
+}

--- a/tests/Helpers/MockMongoDBClient.php
+++ b/tests/Helpers/MockMongoDBClient.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\Geonames\Tests\Helpers;
+
+/**
+ * Mock MongoDB Client for testing without actual MongoDB connection.
+ */
+class MockMongoDBClient
+{
+    /**
+     * @var array<array<string, mixed>>
+     */
+    public array $insertedDocuments = [];
+
+    /**
+     * @var array<array{keys: array<string, mixed>, options: array<string, mixed>}>
+     */
+    public array $createdIndexes = [];
+
+    /**
+     * @var array<string, MockMongoDBDatabase>
+     */
+    private array $databases = [];
+
+    public function selectDatabase(string $name): MockMongoDBDatabase
+    {
+        if (! isset($this->databases[$name])) {
+            $this->databases[$name] = new MockMongoDBDatabase($name, $this);
+        }
+
+        return $this->databases[$name];
+    }
+}
+
+/**
+ * Mock MongoDB Database.
+ */
+class MockMongoDBDatabase
+{
+    private string $name;
+
+    private MockMongoDBClient $client;
+
+    /**
+     * @var array<string, MockMongoDBCollection>
+     */
+    private array $collections = [];
+
+    public function __construct(string $name, MockMongoDBClient $client)
+    {
+        $this->name = $name;
+        $this->client = $client;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function selectCollection(string $name): MockMongoDBCollection
+    {
+        if (! isset($this->collections[$name])) {
+            $this->collections[$name] = new MockMongoDBCollection($name, $this->client);
+        }
+
+        return $this->collections[$name];
+    }
+}
+
+/**
+ * Mock MongoDB Collection.
+ */
+class MockMongoDBCollection
+{
+    private string $name;
+
+    private MockMongoDBClient $client;
+
+    public function __construct(string $name, MockMongoDBClient $client)
+    {
+        $this->name = $name;
+        $this->client = $client;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param  array<string, mixed>  $keys
+     * @param  array<string, mixed>  $options
+     */
+    public function createIndex(array $keys, array $options = []): string
+    {
+        $this->client->createdIndexes[] = ['keys' => $keys, 'options' => $options];
+
+        return 'index_name';
+    }
+
+    /**
+     * @param  array<array<string, mixed>>  $documents
+     * @param  array<string, mixed>  $options
+     */
+    public function insertMany(array $documents, array $options = []): void
+    {
+        foreach ($documents as $doc) {
+            $this->client->insertedDocuments[] = $doc;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @param  array<string, mixed>  $options
+     */
+    public function insertOne(array $document, array $options = []): void
+    {
+        $this->client->insertedDocuments[] = $document;
+    }
+}

--- a/tests/Unit/Converter/AbstractConverterTest.php
+++ b/tests/Unit/Converter/AbstractConverterTest.php
@@ -284,14 +284,14 @@ describe('AbstractConverter', function () {
             expect($result)->toBeInstanceOf(ProgressBar::class);
         });
 
-        it('returns ProgressBar even when total lines is zero', function () {
+        it('returns null when total lines is zero', function () {
             $converter = new TestableConverter;
             $converter->setOutput(new BufferedOutput);
 
             $result = $converter->testCreateProgressBar(0);
 
-            // Converter's createProgressBar doesn't check for zero
-            expect($result)->toBeInstanceOf(ProgressBar::class);
+            // ProgressBar with zero max can cause issues in older Symfony versions
+            expect($result)->toBeNull();
         });
     });
 });

--- a/tests/Unit/Converter/AbstractConverterTest.php
+++ b/tests/Unit/Converter/AbstractConverterTest.php
@@ -173,6 +173,37 @@ describe('AbstractConverter', function () {
                 restore_error_handler();
             }
         })->throws(GeonamesException::class);
+
+        it('handles empty file', function () {
+            $file = $this->getTestDataPath('empty.txt');
+            file_put_contents($file, '');
+
+            $converter = new TestableConverter;
+            $count = $converter->testCountLines($file);
+
+            expect($count)->toBe(0);
+        });
+
+        it('handles file without trailing newline', function () {
+            $file = $this->getTestDataPath('no_newline.txt');
+            file_put_contents($file, "line1\nline2");
+
+            $converter = new TestableConverter;
+            $count = $converter->testCountLines($file);
+
+            // Only counts \n characters
+            expect($count)->toBe(1);
+        });
+
+        it('handles file with only newlines', function () {
+            $file = $this->getTestDataPath('only_newlines.txt');
+            file_put_contents($file, "\n\n\n");
+
+            $converter = new TestableConverter;
+            $count = $converter->testCountLines($file);
+
+            expect($count)->toBe(3);
+        });
     });
 
     describe('streamPostalCodeRecords', function () {
@@ -203,6 +234,36 @@ describe('AbstractConverter', function () {
 
             expect($records)->toBeEmpty();
         });
+
+        it('handles UTF-8 place names', function () {
+            $line = "TH\t10200\tกรุงเทพ\tBangkok\t10\t\t\t\t\t13.7235\t100.5147\t1\n";
+            file_put_contents($this->getTestDataPath('utf8.txt'), $line);
+
+            $converter = new TestableConverter;
+            $records = iterator_to_array($converter->testStreamPostalCodeRecords($this->getTestDataPath('utf8.txt')));
+
+            expect($records[0]['place_name'])->toBe('กรุงเทพ');
+        });
+
+        it('handles empty lines in file', function () {
+            $content = "\n\nTH\t10200\tBang Rak\tBangkok\t10\t\t\t\t\t13.7235\t100.5147\t1\n\n";
+            file_put_contents($this->getTestDataPath('with_empty.txt'), $content);
+
+            $converter = new TestableConverter;
+            $records = iterator_to_array($converter->testStreamPostalCodeRecords($this->getTestDataPath('with_empty.txt')));
+
+            expect($records)->toHaveCount(1);
+        });
+
+        it('parses numeric accuracy field', function () {
+            $line = "TH\t10200\tBang Rak\tBangkok\t10\t\t\t\t\t13.7235\t100.5147\t4\n";
+            file_put_contents($this->getTestDataPath('accuracy.txt'), $line);
+
+            $converter = new TestableConverter;
+            $records = iterator_to_array($converter->testStreamPostalCodeRecords($this->getTestDataPath('accuracy.txt')));
+
+            expect($records[0]['accuracy'])->toBe(4);
+        });
     });
 
     describe('createProgressBar', function () {
@@ -220,6 +281,16 @@ describe('AbstractConverter', function () {
 
             $result = $converter->testCreateProgressBar(100);
 
+            expect($result)->toBeInstanceOf(ProgressBar::class);
+        });
+
+        it('returns ProgressBar even when total lines is zero', function () {
+            $converter = new TestableConverter;
+            $converter->setOutput(new BufferedOutput);
+
+            $result = $converter->testCreateProgressBar(0);
+
+            // Converter's createProgressBar doesn't check for zero
             expect($result)->toBeInstanceOf(ProgressBar::class);
         });
     });

--- a/tests/Unit/Converter/GazetteerConverterTest.php
+++ b/tests/Unit/Converter/GazetteerConverterTest.php
@@ -1,0 +1,236 @@
+<?php
+
+use Farzai\Geonames\Converter\GazetteerConverter;
+use Farzai\Geonames\Exceptions\GeonamesException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Testable wrapper for GazetteerConverter that exposes protected methods.
+ */
+class TestableGazetteerJsonConverter extends GazetteerConverter
+{
+    public function testProcessFile(string $txtFile, string $outputFile): void
+    {
+        $this->processFile($txtFile, $outputFile);
+    }
+
+    /**
+     * @return \Generator<int, array<string, mixed>>
+     */
+    public function testStreamGazetteerRecords(string $txtFile): \Generator
+    {
+        return $this->streamGazetteerRecords($txtFile);
+    }
+
+    public function testLoadAdminCodes(string $adminCodesDir): void
+    {
+        $this->loadAdminCodes($adminCodesDir);
+    }
+}
+
+describe('GazetteerConverter', function () {
+    beforeEach(function () {
+        // Create test data if it doesn't exist
+        if (! file_exists(__DIR__.'/../../stubs/TH_gaz.zip')) {
+            require __DIR__.'/../../stubs/create_test_data.php';
+        }
+    });
+
+    describe('processFile', function () {
+        it('creates valid JSON array output', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('gazetteer.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $content = file_get_contents($this->getTestDataPath('output.json'));
+            $data = json_decode($content, true);
+
+            expect($data)->toBeArray();
+            expect(json_last_error())->toBe(JSON_ERROR_NONE);
+        });
+
+        it('writes correct JSON structure with all gazetteer fields', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+            copy(__DIR__.'/../../stubs/admin1CodesASCII.txt', $this->getTestDataPath('admin1CodesASCII.txt'));
+            copy(__DIR__.'/../../stubs/admin2Codes.txt', $this->getTestDataPath('admin2Codes.txt'));
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testLoadAdminCodes($this->getTestDataPath());
+            $converter->testProcessFile(
+                $this->getTestDataPath('gazetteer.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+
+            expect($data)->not->toBeEmpty();
+            expect($data[0])->toHaveKeys([
+                'geoname_id',
+                'name',
+                'ascii_name',
+                'alternate_names',
+                'latitude',
+                'longitude',
+                'feature_class',
+                'feature_code',
+                'country_code',
+                'admin1_code',
+                'admin2_code',
+                'timezone',
+                'modification_date',
+            ]);
+        });
+
+        it('handles empty file', function () {
+            file_put_contents($this->getTestDataPath('empty.txt'), '');
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('empty.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $content = file_get_contents($this->getTestDataPath('output.json'));
+            expect($content)->toBe('[]');
+        });
+
+        it('handles single record', function () {
+            $line = "1609350\tBangkok\tBangkok\tKrung Thep\t13.75\t100.51667\tP\tPPLC\tTH\t\t40\t01\t\t\t5104476\t2\t4\tAsia/Bangkok\t2023-01-12\n";
+            file_put_contents($this->getTestDataPath('single.txt'), $line);
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('single.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data)->toHaveCount(1);
+            expect($data[0]['name'])->toBe('Bangkok');
+        });
+
+        it('throws on unwritable output path', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+
+            $converter = new TestableGazetteerJsonConverter;
+
+            set_error_handler(fn () => true);
+            try {
+                $converter->testProcessFile(
+                    $this->getTestDataPath('gazetteer.txt'),
+                    '/nonexistent/path/output.json'
+                );
+            } finally {
+                restore_error_handler();
+            }
+        })->throws(GeonamesException::class);
+
+        it('updates progress bar when output is set', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+
+            $output = new BufferedOutput;
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->setOutput($output);
+            $converter->testProcessFile(
+                $this->getTestDataPath('gazetteer.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+
+        it('handles Unicode characters in names', function () {
+            $line = "1609350\tกรุงเทพ\tBangkok\tКрунг Тхеп,曼谷\t13.75\t100.51667\tP\tPPLC\tTH\t\t40\t01\t\t\t5104476\t2\t4\tAsia/Bangkok\t2023-01-12\n";
+            file_put_contents($this->getTestDataPath('unicode.txt'), $line);
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('unicode.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data[0]['name'])->toBe('กรุงเทพ');
+            expect($data[0]['alternate_names'])->toContain('Крунг Тхеп');
+            expect($data[0]['alternate_names'])->toContain('曼谷');
+        });
+
+        it('processes multiple records correctly', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+
+            $converter = new TestableGazetteerJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('gazetteer.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect(count($data))->toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    describe('streamGazetteerRecords', function () {
+        it('yields correct records from file', function () {
+            copy(__DIR__.'/../../stubs/gazetteer.txt', $this->getTestDataPath('gazetteer.txt'));
+
+            $converter = new TestableGazetteerJsonConverter;
+            $records = iterator_to_array($converter->testStreamGazetteerRecords($this->getTestDataPath('gazetteer.txt')));
+
+            expect($records)->not->toBeEmpty();
+            expect($records[0])->toHaveKey('geoname_id');
+            expect($records[0])->toHaveKey('name');
+            expect($records[0])->toHaveKey('latitude');
+            expect($records[0])->toHaveKey('longitude');
+        });
+
+        it('skips empty lines', function () {
+            $content = "\n\n1609350\tBangkok\tBangkok\tKrung Thep\t13.75\t100.51667\tP\tPPLC\tTH\t\t40\t01\t\t\t5104476\t2\t4\tAsia/Bangkok\t2023-01-12\n\n";
+            file_put_contents($this->getTestDataPath('with_blanks.txt'), $content);
+
+            $converter = new TestableGazetteerJsonConverter;
+            $records = iterator_to_array($converter->testStreamGazetteerRecords($this->getTestDataPath('with_blanks.txt')));
+
+            expect($records)->toHaveCount(1);
+        });
+
+        it('throws on unreadable file', function () {
+            $converter = new TestableGazetteerJsonConverter;
+
+            set_error_handler(fn () => true);
+            try {
+                iterator_to_array($converter->testStreamGazetteerRecords('/nonexistent/file.txt'));
+            } finally {
+                restore_error_handler();
+            }
+        })->throws(GeonamesException::class);
+
+        it('yields records with correct latitude and longitude types', function () {
+            $line = "1609350\tBangkok\tBangkok\tKrung Thep\t13.75\t100.51667\tP\tPPLC\tTH\t\t40\t01\t\t\t5104476\t2\t4\tAsia/Bangkok\t2023-01-12\n";
+            file_put_contents($this->getTestDataPath('coords.txt'), $line);
+
+            $converter = new TestableGazetteerJsonConverter;
+            $records = iterator_to_array($converter->testStreamGazetteerRecords($this->getTestDataPath('coords.txt')));
+
+            expect($records[0]['latitude'])->toBe(13.75);
+            expect($records[0]['longitude'])->toBe(100.51667);
+            expect($records[0]['latitude'])->toBeFloat();
+            expect($records[0]['longitude'])->toBeFloat();
+        });
+
+        it('handles records with empty optional fields', function () {
+            // Record with empty cc2, admin3, admin4
+            $line = "1609350\tBangkok\tBangkok\t\t13.75\t100.51667\tP\tPPLC\tTH\t\t40\t01\t\t\t5104476\t\t\tAsia/Bangkok\t2023-01-12\n";
+            file_put_contents($this->getTestDataPath('empty_optional.txt'), $line);
+
+            $converter = new TestableGazetteerJsonConverter;
+            $records = iterator_to_array($converter->testStreamGazetteerRecords($this->getTestDataPath('empty_optional.txt')));
+
+            expect($records[0]['alternate_names'])->toBeArray()->toBeEmpty();
+        });
+    });
+});

--- a/tests/Unit/Converter/MongoDBConvertersProcessingTest.php
+++ b/tests/Unit/Converter/MongoDBConvertersProcessingTest.php
@@ -1,0 +1,224 @@
+<?php
+
+use Farzai\Geonames\Converter\MongoDBGazetteerConverter;
+use Farzai\Geonames\Converter\MongoDBPostalCodeConverter;
+use Farzai\Geonames\Exceptions\GeonamesException;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+
+describe('MongoDBPostalCodeConverter', function () {
+    describe('constructor', function () {
+        it('accepts default parameters', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            expect($converter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        });
+
+        it('accepts custom connection string in constructor', function () {
+            $converter = new MongoDBPostalCodeConverter('mongodb://custom:27017');
+
+            expect($converter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        });
+
+        it('accepts custom database in constructor', function () {
+            $converter = new MongoDBPostalCodeConverter('mongodb://localhost:27017', 'custom_db');
+
+            expect($converter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        });
+
+        it('accepts custom collection in constructor', function () {
+            $converter = new MongoDBPostalCodeConverter(
+                'mongodb://localhost:27017',
+                'geonames',
+                'custom_collection'
+            );
+
+            expect($converter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        });
+    });
+
+    describe('fluent methods', function () {
+        it('setConnectionString returns self', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            $result = $converter->setConnectionString('mongodb://custom:27017');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('setDatabase returns self', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            $result = $converter->setDatabase('test_db');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('setCollection returns self', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            $result = $converter->setCollection('test_collection');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('supports method chaining', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            $result = $converter
+                ->setConnectionString('mongodb://custom:27017')
+                ->setDatabase('test_db')
+                ->setCollection('test_collection')
+                ->setOutput(new NullOutput);
+
+            expect($result)->toBe($converter);
+        });
+
+        it('setConnectionString allows empty string', function () {
+            $converter = new MongoDBPostalCodeConverter;
+
+            $result = $converter->setConnectionString('');
+
+            expect($result)->toBe($converter);
+        });
+    });
+});
+
+describe('MongoDBGazetteerConverter', function () {
+    describe('constructor', function () {
+        it('accepts default parameters for gazetteer', function () {
+            $converter = new MongoDBGazetteerConverter;
+
+            expect($converter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+        });
+
+        it('accepts custom connection string in gazetteer constructor', function () {
+            $converter = new MongoDBGazetteerConverter('mongodb://custom:27017');
+
+            expect($converter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+        });
+
+        it('accepts custom database in gazetteer constructor', function () {
+            $converter = new MongoDBGazetteerConverter('mongodb://localhost:27017', 'custom_db');
+
+            expect($converter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+        });
+
+        it('accepts custom collection in gazetteer constructor', function () {
+            $converter = new MongoDBGazetteerConverter(
+                'mongodb://localhost:27017',
+                'geonames',
+                'custom_gazetteer'
+            );
+
+            expect($converter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+        });
+    });
+
+    describe('fluent methods', function () {
+        it('gazetteer setConnectionString returns self', function () {
+            $converter = new MongoDBGazetteerConverter;
+
+            $result = $converter->setConnectionString('mongodb://custom:27017');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('gazetteer setDatabase returns self', function () {
+            $converter = new MongoDBGazetteerConverter;
+
+            $result = $converter->setDatabase('test_db');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('gazetteer setCollection returns self', function () {
+            $converter = new MongoDBGazetteerConverter;
+
+            $result = $converter->setCollection('test_collection');
+
+            expect($result)->toBe($converter);
+        });
+
+        it('gazetteer supports method chaining', function () {
+            $converter = new MongoDBGazetteerConverter;
+
+            $result = $converter
+                ->setConnectionString('mongodb://custom:27017')
+                ->setDatabase('test_db')
+                ->setCollection('test_collection')
+                ->setOutput(new NullOutput);
+
+            expect($result)->toBe($converter);
+        });
+    });
+
+    describe('output', function () {
+        it('gazetteer accepts BufferedOutput', function () {
+            $converter = new MongoDBGazetteerConverter;
+            $output = new BufferedOutput;
+
+            $result = $converter->setOutput($output);
+
+            expect($result)->toBe($converter);
+        });
+
+        it('gazetteer accepts NullOutput', function () {
+            $converter = new MongoDBGazetteerConverter;
+            $output = new NullOutput;
+
+            $result = $converter->setOutput($output);
+
+            expect($result)->toBe($converter);
+        });
+    });
+});
+
+describe('MongoDB converter exception handling', function () {
+    it('dependencyMissing exception contains correct message', function () {
+        $exception = GeonamesException::dependencyMissing(
+            'MongoDB library',
+            'composer require mongodb/mongodb'
+        );
+
+        expect($exception->getMessage())
+            ->toContain('MongoDB library')
+            ->toContain('composer require');
+    });
+});
+
+describe('MongoDB converter defaults', function () {
+    it('postal converter uses postal_codes as default collection', function () {
+        $converter = new MongoDBPostalCodeConverter(
+            'mongodb://localhost:27017',
+            'geonames'
+        );
+
+        expect($converter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+    });
+
+    it('gazetteer converter uses gazetteer as default collection', function () {
+        $converter = new MongoDBGazetteerConverter(
+            'mongodb://localhost:27017',
+            'geonames'
+        );
+
+        expect($converter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+    });
+
+    it('both converters use geonames as default database', function () {
+        $postalConverter = new MongoDBPostalCodeConverter;
+        $gazetteerConverter = new MongoDBGazetteerConverter;
+
+        expect($postalConverter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        expect($gazetteerConverter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+    });
+
+    it('both converters use localhost as default connection', function () {
+        $postalConverter = new MongoDBPostalCodeConverter;
+        $gazetteerConverter = new MongoDBGazetteerConverter;
+
+        expect($postalConverter)->toBeInstanceOf(MongoDBPostalCodeConverter::class);
+        expect($gazetteerConverter)->toBeInstanceOf(MongoDBGazetteerConverter::class);
+    });
+});

--- a/tests/Unit/Converter/PostalCodeConverterTest.php
+++ b/tests/Unit/Converter/PostalCodeConverterTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use Farzai\Geonames\Converter\PostalCodeConverter;
+use Farzai\Geonames\Exceptions\GeonamesException;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Testable wrapper for PostalCodeConverter that exposes protected methods.
+ */
+class TestablePostalCodeJsonConverter extends PostalCodeConverter
+{
+    public function testProcessFile(string $txtFile, string $outputFile): void
+    {
+        $this->processFile($txtFile, $outputFile);
+    }
+}
+
+describe('PostalCodeConverter', function () {
+    beforeEach(function () {
+        // Create test data if it doesn't exist
+        if (! file_exists(__DIR__.'/../../stubs/TH.zip')) {
+            require __DIR__.'/../../stubs/create_test_data.php';
+        }
+    });
+
+    describe('processFile', function () {
+        it('creates valid JSON array output', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('postal.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $content = file_get_contents($this->getTestDataPath('output.json'));
+            $data = json_decode($content, true);
+
+            expect($data)->toBeArray();
+            expect(json_last_error())->toBe(JSON_ERROR_NONE);
+        });
+
+        it('writes correct JSON structure with postal code fields', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('postal.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+
+            expect($data)->not->toBeEmpty();
+            expect($data[0])->toHaveKeys([
+                'country_code',
+                'postal_code',
+                'place_name',
+                'admin_name1',
+                'admin_code1',
+                'latitude',
+                'longitude',
+            ]);
+        });
+
+        it('handles empty file', function () {
+            file_put_contents($this->getTestDataPath('empty.txt'), '');
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('empty.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $content = file_get_contents($this->getTestDataPath('output.json'));
+            // Empty file produces "[\n\n]" because opening bracket + newline + closing bracket
+            expect($content)->toBe("[\n\n]");
+        });
+
+        it('preserves latitude and longitude precision', function () {
+            $line = "US\t90210\tBeverly Hills\tCalifornia\tCA\t\t\t\t\t34.0901234\t-118.4065432\t1\n";
+            file_put_contents($this->getTestDataPath('precision.txt'), $line);
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('precision.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data[0]['latitude'])->toBe(34.0901234);
+            expect($data[0]['longitude'])->toBe(-118.4065432);
+        });
+
+        it('handles empty latitude and longitude as zero', function () {
+            // When lat/long fields exist but are empty, they become 0.0 (not null)
+            $line = "US\t90210\tBeverly Hills\tCalifornia\tCA\t\t\t\t\t\t\t1\n";
+            file_put_contents($this->getTestDataPath('empty_coords.txt'), $line);
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('empty_coords.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            // Empty string cast to float becomes 0.0, JSON decode may return as int 0
+            expect($data[0]['latitude'])->toEqual(0);
+            expect($data[0]['longitude'])->toEqual(0);
+        });
+
+        it('throws on unwritable output path', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $converter = new TestablePostalCodeJsonConverter;
+
+            set_error_handler(fn () => true);
+            try {
+                $converter->testProcessFile(
+                    $this->getTestDataPath('postal.txt'),
+                    '/nonexistent/path/output.json'
+                );
+            } finally {
+                restore_error_handler();
+            }
+        })->throws(GeonamesException::class);
+
+        it('formats JSON with newlines', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('postal.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $content = file_get_contents($this->getTestDataPath('output.json'));
+            expect($content)->toStartWith("[\n");
+            expect($content)->toEndWith("\n]");
+        });
+
+        it('updates progress bar when output is set', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $output = new BufferedOutput;
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->setOutput($output);
+            $converter->testProcessFile(
+                $this->getTestDataPath('postal.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+
+        it('handles UTF-8 place names', function () {
+            $line = "TH\t10200\tกรุงเทพ\tBangkok\t10\t\t\t\t\t13.7235\t100.5147\t1\n";
+            file_put_contents($this->getTestDataPath('utf8.txt'), $line);
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('utf8.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data[0]['place_name'])->toBe('กรุงเทพ');
+        });
+
+        it('processes multiple records with correct separators', function () {
+            copy(__DIR__.'/../../stubs/postal_codes.txt', $this->getTestDataPath('postal.txt'));
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('postal.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect(count($data))->toBeGreaterThanOrEqual(1);
+
+            // Verify the file is valid JSON (commas properly placed)
+            expect(json_last_error())->toBe(JSON_ERROR_NONE);
+        });
+
+        it('handles single record', function () {
+            $line = "TH\t10200\tBang Rak\tBangkok\t10\t\t\t\t\t13.7235\t100.5147\t1\n";
+            file_put_contents($this->getTestDataPath('single.txt'), $line);
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('single.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data)->toHaveCount(1);
+            expect($data[0]['postal_code'])->toBe('10200');
+            expect($data[0]['place_name'])->toBe('Bang Rak');
+        });
+
+        it('handles records with all admin fields', function () {
+            $line = "US\t10001\tNew York\tNew York\tNY\tNew York\t061\tManhattan\t36061\t40.7128\t-74.006\t4\n";
+            file_put_contents($this->getTestDataPath('full_admin.txt'), $line);
+
+            $converter = new TestablePostalCodeJsonConverter;
+            $converter->testProcessFile(
+                $this->getTestDataPath('full_admin.txt'),
+                $this->getTestDataPath('output.json')
+            );
+
+            $data = json_decode(file_get_contents($this->getTestDataPath('output.json')), true);
+            expect($data[0]['admin_name1'])->toBe('New York');
+            expect($data[0]['admin_code1'])->toBe('NY');
+        });
+    });
+});

--- a/tests/Unit/Downloader/AbstractDownloaderTest.php
+++ b/tests/Unit/Downloader/AbstractDownloaderTest.php
@@ -1,0 +1,249 @@
+<?php
+
+use Farzai\Geonames\Downloader\AbstractDownloader;
+use Farzai\Geonames\Exceptions\GeonamesException;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * Testable wrapper for AbstractDownloader that exposes protected methods.
+ */
+class TestableAbstractDownloader extends AbstractDownloader
+{
+    protected function getBaseUrl(): string
+    {
+        return 'https://test.example.com/';
+    }
+
+    public function testDownloadWithProgress(string $url, string $destination): void
+    {
+        $this->downloadWithProgress($url, $destination);
+    }
+
+    public function testCreateProgressBar(int $totalSize): ?ProgressBar
+    {
+        return $this->createProgressBar($totalSize);
+    }
+
+    public function testFinishProgressBar(?ProgressBar $progressBar): void
+    {
+        $this->finishProgressBar($progressBar);
+    }
+
+    public function testGetBaseUrl(): string
+    {
+        return $this->getBaseUrl();
+    }
+}
+
+describe('AbstractDownloader', function () {
+    describe('setOutput', function () {
+        it('returns self for method chaining', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+
+            $result = $downloader->setOutput(new NullOutput);
+
+            expect($result)->toBe($downloader);
+        });
+    });
+
+    describe('downloadWithProgress', function () {
+        it('saves file correctly', function () {
+            $content = 'test file content';
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => [(string) strlen($content)]]],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/file.txt',
+                $this->getTestDataPath('downloaded.txt')
+            );
+
+            expect(file_exists($this->getTestDataPath('downloaded.txt')))->toBeTrue();
+            expect(file_get_contents($this->getTestDataPath('downloaded.txt')))->toBe($content);
+        });
+
+        it('shows progress when output set', function () {
+            $content = str_repeat('x', 10000);
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => [(string) strlen($content)]]],
+            ]);
+
+            $output = new BufferedOutput;
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput($output);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/file.txt',
+                $this->getTestDataPath('downloaded.txt')
+            );
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+
+        it('works without output set', function () {
+            $content = 'test content';
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => [(string) strlen($content)]]],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/file.txt',
+                $this->getTestDataPath('downloaded.txt')
+            );
+
+            expect(file_exists($this->getTestDataPath('downloaded.txt')))->toBeTrue();
+        });
+
+        it('handles empty Content-Length header', function () {
+            $content = 'test content';
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => []],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/file.txt',
+                $this->getTestDataPath('downloaded.txt')
+            );
+
+            expect(file_exists($this->getTestDataPath('downloaded.txt')))->toBeTrue();
+            expect(file_get_contents($this->getTestDataPath('downloaded.txt')))->toBe($content);
+        });
+
+        it('handles zero Content-Length header', function () {
+            $content = 'test content';
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => ['0']]],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput(new BufferedOutput);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/file.txt',
+                $this->getTestDataPath('downloaded.txt')
+            );
+
+            expect(file_exists($this->getTestDataPath('downloaded.txt')))->toBeTrue();
+        });
+
+        it('throws on write failure', function () {
+            $content = 'test content';
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => [(string) strlen($content)]]],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+
+            set_error_handler(fn () => true);
+            try {
+                $downloader->testDownloadWithProgress(
+                    'https://test.example.com/file.txt',
+                    '/nonexistent/path/file.txt'
+                );
+            } finally {
+                restore_error_handler();
+            }
+        })->throws(GeonamesException::class);
+
+        it('downloads large files in chunks', function () {
+            // Create content larger than CHUNK_SIZE (8192)
+            $content = str_repeat('x', 20000);
+            $transport = MockHttpClient::createTransport([
+                ['content' => $content, 'headers' => ['Content-Length' => [(string) strlen($content)]]],
+            ]);
+
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->testDownloadWithProgress(
+                'https://test.example.com/large.txt',
+                $this->getTestDataPath('large.txt')
+            );
+
+            expect(file_exists($this->getTestDataPath('large.txt')))->toBeTrue();
+            expect(strlen(file_get_contents($this->getTestDataPath('large.txt'))))->toBe(20000);
+        });
+    });
+
+    describe('createProgressBar', function () {
+        it('returns null when no output set', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+
+            $result = $downloader->testCreateProgressBar(100);
+
+            expect($result)->toBeNull();
+        });
+
+        it('returns null when size is zero', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput(new BufferedOutput);
+
+            $result = $downloader->testCreateProgressBar(0);
+
+            expect($result)->toBeNull();
+        });
+
+        it('returns ProgressBar with output and size', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput(new BufferedOutput);
+
+            $result = $downloader->testCreateProgressBar(100);
+
+            expect($result)->toBeInstanceOf(ProgressBar::class);
+        });
+
+        it('configures progress bar format', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $output = new BufferedOutput;
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput($output);
+
+            $progressBar = $downloader->testCreateProgressBar(100);
+            $progressBar->setProgress(50);
+            $progressBar->finish();
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+    });
+
+    describe('finishProgressBar', function () {
+        it('handles null gracefully', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+
+            $downloader->testFinishProgressBar(null);
+
+            expect(true)->toBeTrue(); // No exception thrown
+        });
+
+        it('finishes and adds newline', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $output = new BufferedOutput;
+            $downloader = new TestableAbstractDownloader($transport);
+            $downloader->setOutput($output);
+
+            $progressBar = $downloader->testCreateProgressBar(100);
+            $downloader->testFinishProgressBar($progressBar);
+
+            $display = $output->fetch();
+            expect($display)->toContain("\n");
+        });
+    });
+
+    describe('getBaseUrl', function () {
+        it('returns correct base URL', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new TestableAbstractDownloader($transport);
+
+            expect($downloader->testGetBaseUrl())->toBe('https://test.example.com/');
+        });
+    });
+});

--- a/tests/Unit/Downloader/GazetteerDownloaderTest.php
+++ b/tests/Unit/Downloader/GazetteerDownloaderTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use Farzai\Geonames\Downloader\GazetteerDownloader;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe('GazetteerDownloader', function () {
+    beforeEach(function () {
+        if (! file_exists(__DIR__.'/../../stubs/TH_gaz.zip')) {
+            require __DIR__.'/../../stubs/create_test_data.php';
+        }
+    });
+
+    describe('download', function () {
+        it('downloads country zip file', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('TH.zip')))->toBeTrue();
+        });
+
+        it('uppercases lowercase country code', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->download('th', $this->getTestDataPath());
+
+            // File is saved as uppercase
+            expect(file_exists($this->getTestDataPath('TH.zip')))->toBeTrue();
+        });
+
+        it('downloads admin code files', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('admin1CodesASCII.txt')))->toBeTrue();
+            expect(file_exists($this->getTestDataPath('admin2Codes.txt')))->toBeTrue();
+        });
+
+        it('outputs download messages when output set', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $output = new BufferedOutput;
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->setOutput($output);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            $display = $output->fetch();
+            expect($display)->toContain('admin1CodesASCII.txt');
+            expect($display)->toContain('admin2Codes.txt');
+        });
+
+        it('saves admin code files with correct content', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            expect(file_get_contents($this->getTestDataPath('admin1CodesASCII.txt')))->toBe($admin1Content);
+            expect(file_get_contents($this->getTestDataPath('admin2Codes.txt')))->toBe($admin2Content);
+        });
+    });
+
+    describe('downloadAll', function () {
+        it('downloads allCountries.zip', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('allCountries.zip')))->toBeTrue();
+        });
+
+        it('also downloads admin codes', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('admin1CodesASCII.txt')))->toBeTrue();
+            expect(file_exists($this->getTestDataPath('admin2Codes.txt')))->toBeTrue();
+        });
+
+        it('shows progress when output set', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH_gaz.zip');
+            $admin1Content = file_get_contents(__DIR__.'/../../stubs/admin1CodesASCII.txt');
+            $admin2Content = file_get_contents(__DIR__.'/../../stubs/admin2Codes.txt');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+                ['content' => $admin1Content, 'headers' => ['Content-Length' => [(string) strlen($admin1Content)]]],
+                ['content' => $admin2Content, 'headers' => ['Content-Length' => [(string) strlen($admin2Content)]]],
+            ]);
+
+            $output = new BufferedOutput;
+            $downloader = new GazetteerDownloader($transport);
+            $downloader->setOutput($output);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+    });
+
+    describe('setOutput', function () {
+        it('returns self for method chaining', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new GazetteerDownloader($transport);
+
+            $result = $downloader->setOutput(new BufferedOutput);
+
+            expect($result)->toBe($downloader);
+        });
+    });
+});

--- a/tests/Unit/Downloader/GeonamesDownloaderTest.php
+++ b/tests/Unit/Downloader/GeonamesDownloaderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use Farzai\Geonames\Downloader\GeonamesDownloader;
+use Farzai\Geonames\Tests\Helpers\MockHttpClient;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+describe('GeonamesDownloader', function () {
+    beforeEach(function () {
+        if (! file_exists(__DIR__.'/../../stubs/TH.zip')) {
+            require __DIR__.'/../../stubs/create_test_data.php';
+        }
+    });
+
+    describe('download', function () {
+        it('downloads country zip file', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->download('US', $this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('US.zip')))->toBeTrue();
+        });
+
+        it('uppercases lowercase country code', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->download('us', $this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('US.zip')))->toBeTrue();
+        });
+
+        it('saves to correct destination', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            mkdir($this->getTestDataPath('subdir'));
+            $downloader->download('TH', $this->getTestDataPath('subdir'));
+
+            expect(file_exists($this->getTestDataPath('subdir/TH.zip')))->toBeTrue();
+        });
+
+        it('saves correct file content', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            expect(file_get_contents($this->getTestDataPath('TH.zip')))->toBe($zipContent);
+        });
+
+        it('shows progress when output set', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $output = new BufferedOutput;
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->setOutput($output);
+            $downloader->download('TH', $this->getTestDataPath());
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+    });
+
+    describe('downloadAll', function () {
+        it('downloads allCountries.zip', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            expect(file_exists($this->getTestDataPath('allCountries.zip')))->toBeTrue();
+        });
+
+        it('saves correct file content', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            expect(file_get_contents($this->getTestDataPath('allCountries.zip')))->toBe($zipContent);
+        });
+
+        it('shows progress when output set', function () {
+            $zipContent = file_get_contents(__DIR__.'/../../stubs/TH.zip');
+
+            $transport = MockHttpClient::createTransport([
+                ['content' => $zipContent, 'headers' => ['Content-Length' => [(string) strlen($zipContent)]]],
+            ]);
+
+            $output = new BufferedOutput;
+            $downloader = new GeonamesDownloader($transport);
+            $downloader->setOutput($output);
+            $downloader->downloadAll($this->getTestDataPath());
+
+            $display = $output->fetch();
+            expect($display)->toContain('%');
+        });
+    });
+
+    describe('setOutput', function () {
+        it('returns self for method chaining', function () {
+            $transport = MockHttpClient::createTransport([]);
+            $downloader = new GeonamesDownloader($transport);
+
+            $result = $downloader->setOutput(new BufferedOutput);
+
+            expect($result)->toBe($downloader);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Replace `guzzlehttp/guzzle` with `farzai/transport` for HTTP requests
- Implement streaming in `GazetteerConverter` for O(1) memory complexity when processing large datasets
- Modernize Symfony Console commands to use PHP 8 `#[AsCommand]` attributes
- Improve error handling with proper file write checking
- Update README documentation with better explanations

## Changes

### HTTP Client Migration
Replaced Guzzle with `farzai/transport` library for HTTP operations, simplifying the dependency chain.

### Memory Optimization
Added generator-based streaming in `GazetteerConverter` to process large GeoNames files without loading everything into memory. Records are yielded one at a time for constant memory usage.

### Code Modernization
- Use `#[AsCommand]` attributes instead of static `$defaultName` and `$defaultDescription` properties
- Add `writeToHandle()` methods with proper error checking in converters

### Documentation
- Add "How It Works" section explaining admin code resolution, memory-efficient processing, and automatic cleanup
- Add "Error Handling" section with common error scenarios
- Update MongoDB format documentation

### New Tests
Added comprehensive unit tests:
- `tests/Helpers/MockHttpClient.php` - HTTP client mocking
- `tests/Helpers/MockMongoDBClient.php` - MongoDB client mocking  
- `tests/Unit/Converter/GazetteerConverterTest.php`
- `tests/Unit/Converter/PostalCodeConverterTest.php`
- `tests/Unit/Converter/MongoDBConvertersProcessingTest.php`
- `tests/Unit/Downloader/AbstractDownloaderTest.php`
- `tests/Unit/Downloader/GazetteerDownloaderTest.php`
- `tests/Unit/Downloader/GeonamesDownloaderTest.php`

## Test plan
- [ ] Run `composer test` to verify all tests pass
- [ ] Test postal code download: `./bin/geonames geonames:download TH`
- [ ] Test gazetteer download: `./bin/geonames geonames:gazetteer:download TH`
- [ ] Verify MongoDB export works (if MongoDB available)