### PR TITLE
Add PHP 8.4 and 8.3 to CI test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: 
+        os:
           - ubuntu-latest
           - windows-latest
-        php: [8.2, 8.1]
-        stability: 
+        php: [8.4, 8.3, 8.2, 8.1]
+        stability:
           - prefer-lowest
           - prefer-stable
 


### PR DESCRIPTION
## Summary
- Adds PHP 8.4 and 8.3 to the GitHub Actions test matrix
- Ensures compatibility testing with the latest PHP versions
- Maintains existing support for PHP 8.2 and 8.1

## Test plan
- [ ] Verify CI runs successfully on all PHP versions (8.4, 8.3, 8.2, 8.1)
- [ ] Confirm tests pass on both Ubuntu and Windows